### PR TITLE
Feat/folder right click delete

### DIFF
--- a/backend/src/socketHandlers/editorHandler.js
+++ b/backend/src/socketHandlers/editorHandler.js
@@ -98,20 +98,6 @@ export const handleEditorSocketEvents = (socket, editorNamespace) => {
         }
     });
 
-    socket.on("renameFolder", async ({ oldFolderPath, newFolderPath }) => {
-        try {
-          await fs.rename(oldFolderPath, newFolderPath);
-          socket.emit("renameFolderSuccess", {
-            data: "Folder renamed successfully",
-            oldPath: oldFolderPath,
-            newPath: newFolderPath,
-          });
-        } catch (error) {
-          console.log("Error in renaming the folder", error);
-          socket.emit("error", {
-            data: "Error in renaming the folder",
-          });
-        }
-      });
+
 
 }

--- a/frontend/src/components/molecules/ContextMenu/FolderContextMenu.jsx
+++ b/frontend/src/components/molecules/ContextMenu/FolderContextMenu.jsx
@@ -1,0 +1,56 @@
+import "./fileContextMenu.css";
+import { useEditorSocketStore } from "../../../store/editorSocketStore";
+import { useFolderContextMenuStore } from "../../../store/folderContextMenuStore";
+
+
+export const FolderContextMenu = () => {
+  const { x, y, isOpen, folderPath, reset } =
+    useFolderContextMenuStore();
+
+  const { editorSocket } = useEditorSocketStore();
+
+  if (!isOpen) return null;
+
+ 
+  const handleNewFile = (e) => {
+    e.preventDefault();
+   
+  };
+
+  const handleNewFolder = (e) => {
+    e.preventDefault();
+    
+  };
+
+  const handleRenameFolder = (e) => {
+    e.preventDefault();
+    
+  };
+
+  const handleDeleteFolder = (e) => {
+    e.preventDefault();
+    editorSocket.emit("deleteFolder", { pathToFileOrFolder: folderPath });
+    reset();
+  };
+
+  return (
+    <div
+      className="fileContextOptionsWrapper"
+      style={{ left: x, top: y }}
+      onMouseLeave={() => reset()}
+    >
+      <button className="fileContextButton" onClick={handleNewFile}>
+        New File
+      </button>
+      <button className="fileContextButton" onClick={handleNewFolder}>
+        New Folder
+      </button>
+      <button className="fileContextButton" onClick={handleRenameFolder}>
+        Rename Folder
+      </button>
+      <button className="fileContextButton" onClick={handleDeleteFolder}>
+        Delete Folder
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/molecules/TreeNode/TreeNode.jsx
+++ b/frontend/src/components/molecules/TreeNode/TreeNode.jsx
@@ -3,6 +3,7 @@ import { IoIosArrowDown, IoIosArrowForward } from "react-icons/io";
 import { FileIcon } from "../../atoms/FileIcon/Fileicon";
 import { useEditorSocketStore } from "../../../store/editorSocketStore";
 import { useFileContextMenuStore } from "../../../store/fileContextMenuStore";
+import { useFolderContextMenuStore } from "../../../store/folderContextMenuStore";
 
 export const TreeNode = ({
     fileFolderData
@@ -18,6 +19,13 @@ export const TreeNode = ({
         setX: setFileContextMenuX,
         setY: setFileContextMenuY
     } = useFileContextMenuStore();
+
+    const {
+        setFolderPath,
+        setIsOpen: setFolderContextMenuIsOpen,
+        setX: setFolderContextMenuX,
+        setY: setFolderContextMenuY,
+      } = useFolderContextMenuStore();
 
     function toggleVisibility(name) {
         setVisibility({
@@ -48,6 +56,15 @@ export const TreeNode = ({
         setFileContextMenuIsOpen(true);
     }
 
+    function handleContextMenuForFolders(e, path) {
+        e.preventDefault();
+        console.log("Right clicked on folder:", path);
+        setFolderPath(path);
+        setFolderContextMenuX(e.clientX);
+        setFolderContextMenuY(e.clientY);
+        setFolderContextMenuIsOpen(true);
+      }
+
     useEffect(() => {
         console.log("Visibility chanmged", visibility); 
     }, [visibility])
@@ -64,6 +81,9 @@ export const TreeNode = ({
                 /** If the current node is a folder, render it as a button */
                 <button
                     onClick={() => toggleVisibility(fileFolderData.name)}
+                    onContextMenu={(e) =>
+                        handleContextMenuForFolders(e, fileFolderData.path)
+                      }
                     style={{
                         border: "none",
                         cursor: "pointer",

--- a/frontend/src/components/organisms/TreeStructure/TreeStructure.jsx
+++ b/frontend/src/components/organisms/TreeStructure/TreeStructure.jsx
@@ -3,6 +3,8 @@ import { useEffect } from "react";
 import { TreeNode } from "../../molecules/TreeNode/TreeNode";
 import { useFileContextMenuStore } from "../../../store/fileContextMenuStore";
 import { FileContextMenu } from "../../molecules/ContextMenu/FileContextMenu";
+import { useFolderContextMenuStore } from "../../../store/folderContextMenuStore";
+import { FolderContextMenu } from "../../molecules/ContextMenu/FolderContextMenu";
 
 export const TreeStructure = () => {
 
@@ -13,6 +15,14 @@ export const TreeStructure = () => {
         x: fileContextX, 
         y: fileContextY } = useFileContextMenuStore();
 
+        const {
+            folderPath,
+            isOpen: isFolderContextOpen,
+            x: folderContextX,
+            y: folderContextY,
+            reset: resetFolderContextMenu,
+          } = useFolderContextMenuStore();
+
     useEffect(() => {
         if(treeStructure) {
             console.log("tree:", treeStructure);
@@ -20,6 +30,10 @@ export const TreeStructure = () => {
             setTreeStructure();
         }
     }, [setTreeStructure, treeStructure]);
+
+    const handleCloseContextMenus = () => {
+        resetFolderContextMenu();
+      };
 
     return (
         <>
@@ -30,6 +44,14 @@ export const TreeStructure = () => {
                 path={file}
             />
         )}
+        {isFolderContextOpen && folderContextX && folderContextY && (
+        <FolderContextMenu
+          x={folderContextX}
+          y={folderContextY}
+          path={folderPath}
+          onClose={handleCloseContextMenus}
+        />
+      )}
             <TreeNode
                 fileFolderData={treeStructure}
             />

--- a/frontend/src/store/editorSocketStore.js
+++ b/frontend/src/store/editorSocketStore.js
@@ -26,6 +26,11 @@ export const useEditorSocketStore = create((set) => ({
         incomingSocket?.on("deleteFileSuccess", () => {
             projectTreeStructureSetter();
         });
+        
+        incomingSocket?.on("deleteFolderSuccess", (data) => {
+            console.log("Delete folder success", data);
+            projectTreeStructureSetter();
+          });
 
         set({
             editorSocket: incomingSocket

--- a/frontend/src/store/folderContextMenuStore.js
+++ b/frontend/src/store/folderContextMenuStore.js
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+
+export const useFolderContextMenuStore = create((set) => ({
+  x: null,
+  y: null,
+  isOpen: false,
+  folderPath: null,
+
+  
+  setX: (incomingX) => {
+    set({ x: incomingX });
+  },
+
+  
+  setY: (incomingY) => {
+    set({ y: incomingY });
+  },
+
+ 
+  setIsOpen: (incomingIsOpen) => {
+    set({ isOpen: incomingIsOpen });
+  },
+
+  
+  setFolderPath: (incomingFolderPath) => {
+    set({ folderPath: incomingFolderPath });
+  },
+
+  // Reset all state
+  reset: () => {
+    set({
+      x: null,
+      y: null,
+      isOpen: false,
+      folderPath: null,
+    });
+  },
+}));


### PR DESCRIPTION
### **Pull Request Title**  
**Add Folder Right-Click Context Menu with Delete Folder Option**  

---

### **Description**  
This PR introduces the ability to open a context menu for folders on right-click, with a **Delete Folder** action. The changes include:  
1. **Folder Context Menu**:  
   - A new `FolderContextMenu` component that includes options like "New File," "New Folder," "Rename Folder," and "Delete Folder."  
   - The `deleteFolder` action emits a socket event to notify the server and updates the project tree structure.

2. **Context Menu State Management**:  
   - Created `folderContextMenuStore` using `Zustand` to manage the position, visibility, and folder path for the right-click context menu.

3. **Integration in Tree Node**:  
   - Added `onContextMenu` event to folders in the `TreeNode` component to trigger the context menu.

4. **Tree Structure Context Menu Handling**:  
   - Enhanced the `TreeStructure` component to handle both file and folder context menus.

5. **Socket Event Listener**:  
   - Added a `deleteFolderSuccess` event in `editorSocketStore` to refresh the project tree structure after successfully deleting a folder.
   
![image](https://github.com/user-attachments/assets/79187d74-14ba-4fef-9ef8-908fe1541705)

---

### **Key Changes**  
- **Added** `FolderContextMenu` component.  
- **Created** `folderContextMenuStore` for folder-specific context menu state.  
- **Modified** `TreeNode` to handle folder right-click events.  
- **Updated** `TreeStructure` to display folder context menus alongside file menus.  
- **Enhanced** `editorSocketStore` with `deleteFolderSuccess` socket event.