### PR TITLE
Feat/edtior file button on top bar or editor 

### DIFF
--- a/frontend/src/components/atoms/EditorButton/EditorButton.css
+++ b/frontend/src/components/atoms/EditorButton/EditorButton.css
@@ -1,12 +1,38 @@
+.editor-tab {
+    display: flex;
+    align-items: center;
+    margin-right: 5px;
+    position: relative;
+}
+
 .editor-button {
-    outline: none;
-    background-color: #303242;
+    padding: 5px 10px;
+    border: none;
+    cursor: pointer;
     font-size: 14px;
-    height: 30px;
-    border-left: none;
-    border-bottom: none;
-    border-top: 1px solid #f7b9dd;
-    color: white;
-    min-width: 100px;
-    padding: 3px 7px 3px 7px;
+    font-weight: 500;
+    border-radius: 3px;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.editor-button:hover {
+    background-color: #4a4859;
+}
+
+.close-button {
+    background-color: transparent;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: #ff5555;
+    padding: 0;
+    margin-left: 5px;
+}
+
+.editor-tab.active .editor-button {
+    border-top: 2px solid #f7b9dd;
+}
+
+.editor-tab.error .editor-button {
+    color: #ff5555;
 }

--- a/frontend/src/components/atoms/EditorButton/EditorButton.jsx
+++ b/frontend/src/components/atoms/EditorButton/EditorButton.jsx
@@ -1,21 +1,58 @@
 import './EditorButton.css';
 
-export const EditorButton = ({ isActive }) => {
+export const EditorButton = ({ 
+    isActive,
+    fileName,
+    hasError,
+    onClose,
+    onClick
+}) => {
 
-    function handleClick() {
-        // TODO: Implement click handler
-    }
     return (
-        <button
-            className="editor-button"
+        <div
+            className={`editor-tab ${isActive ? 'active' : ''} ${hasError ? 'error' : ''}`}
             style={{
-                color: isActive ? 'white' : '#959eba',
-                backgroundColor: isActive ? '#303242' : '#4a4859',
-                borderTop: isActive ? '2px solid #f7b9dd' : 'none',
+                maxWidth: isActive ? "200px" : "150px",
             }}
-            onClick={handleClick}
         >
-            file.js
-        </button>
-    )
-}
+            <div style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                width: '100%',
+            }}>
+                {/* File Name Tab */}
+                <button
+                    className="editor-button"
+                    style={{
+                        color: isActive ? 'white' : '#959eba',
+                        backgroundColor: isActive ? '#303242' : '#4a4859',
+                        borderTop: isActive ? '2px solid #f7b9dd' : 'none',
+                        flexGrow: 1,
+                        padding: '5px 10px',
+                        border: 'none',
+                        cursor: 'pointer'
+                    }}
+                    onClick={onClick}
+                >
+                    {fileName}
+                </button>
+
+                {/* Close Button */}
+                <button
+                    onClick={onClose}
+                    style={{
+                        marginLeft: '8px',
+                        color: "#ff5555",
+                        cursor: "pointer",
+                        backgroundColor: "transparent",
+                        fontSize: "16px",
+                        border: "none",
+                    }}
+                >
+                    x
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/molecules/TabContainer/TabsContainer.jsx
+++ b/frontend/src/components/molecules/TabContainer/TabsContainer.jsx
@@ -1,0 +1,37 @@
+import { useActiveFileTabStore } from "../../../store/activeFileTabStore";
+import { EditorButton } from "../../atoms/EditorButton/EditorButton"; // Import EditorButton
+
+export const TabContainer = () => {
+    const { tabs, activeFileTab, setActiveTab, closeTab } = useActiveFileTabStore();
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                alignItems: "center",
+                backgroundColor: "#333254",
+                borderBottom: "1px solid #444",
+                padding: "5px",
+                overflowX : "auto",
+                whiteSpace : "nowrap",
+                minWidth : "50px"
+            }}
+        >
+            {tabs.map((tab) => (
+                <EditorButton
+                    key={tab.path}
+                    isActive={activeFileTab?.path === tab.path}
+                    fileName={tab.name} 
+                    hasError={false}
+                    onClose={(e) => {
+                        e.stopPropagation();
+                        closeTab(tab.path); 
+                    }}
+                    onClick={() => {
+                        setActiveTab(tab.path);
+                    }}
+                />
+            ))}
+        </div>
+    );
+};

--- a/frontend/src/components/molecules/TreeNode/TreeNode.jsx
+++ b/frontend/src/components/molecules/TreeNode/TreeNode.jsx
@@ -3,6 +3,7 @@ import { IoIosArrowDown, IoIosArrowForward } from "react-icons/io";
 import { FileIcon } from "../../atoms/FileIcon/Fileicon";
 import { useEditorSocketStore } from "../../../store/editorSocketStore";
 import { useFileContextMenuStore } from "../../../store/fileContextMenuStore";
+import { useActiveFileTabStore } from "../../../store/activeFileTabStore";
 
 export const TreeNode = ({
     fileFolderData
@@ -11,6 +12,8 @@ export const TreeNode = ({
     const [visibility, setVisibility] = useState({});
 
     const { editorSocket } = useEditorSocketStore();
+
+    const {setActiveFileTab} = useActiveFileTabStore();
 
     const {
         setFile,
@@ -37,6 +40,8 @@ export const TreeNode = ({
         editorSocket.emit("readFile", {
             pathToFileOrFolder: fileFolderData.path
         })
+        console.log(fileFolderData);
+        setActiveFileTab(fileFolderData.path, "", fileFolderData.name.split(".").pop());
     }
 
     function handleContextMenuForFiles(e, path) {

--- a/frontend/src/pages/ProjectPlayground.jsx
+++ b/frontend/src/pages/ProjectPlayground.jsx
@@ -11,6 +11,7 @@ import { Browser } from "../components/organisms/Browser/Browser";
 import { Button } from "antd";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
+import { TabContainer } from "../components/molecules/TabContainer/TabsContainer";
 export const ProjectPlayground = () => {
 
     const {projectId: projectIdFromUrl } = useParams();
@@ -79,7 +80,7 @@ export const ProjectPlayground = () => {
 
                         }}
                     >
-
+                    <TabContainer />
                     <Allotment
                         vertical={true}
                     >
@@ -102,12 +103,7 @@ export const ProjectPlayground = () => {
                 </Allotment>
 
             </div>
-        </div>
-           
-            {/* <EditorButton isActive={false} /> 
-            <EditorButton isActive={true}/>  */}
-            
-            
+        </div> 
         </>
     )
 }

--- a/frontend/src/store/activeFileTabStore.js
+++ b/frontend/src/store/activeFileTabStore.js
@@ -1,16 +1,57 @@
-import { create } from 'zustand';
+import { create } from "zustand";
 
 export const useActiveFileTabStore = create((set) => {
     return {
         activeFileTab: null,
+        tabs: [],
         setActiveFileTab: (path, value, extension) => {
-            set( {
-                activeFileTab: {
-                    path: path,
-                    value: value,
-                    extension: extension
+            set((state) => {
+                const tabExists = state.tabs.some((tab) => tab.path === path);
+                return {
+                    activeFileTab: { path, value, extension },
+                    tabs: tabExists
+                        ? state.tabs
+                        : [
+                            ...state.tabs,
+                            { path, name: path.replace(/\\/g, '/').split('/').pop(), extension, value }
+                        ]
+                };
+            });
+        },
+
+        setActiveTab: (path) => {
+            set((state) => {
+                const tab = state.tabs.find((t) => t.path === path);
+                console.log(state.tabs);
+                
+                if (tab) {
+                    return {
+                        activeFileTab: { ...tab }
+                    };
                 }
-            })
+                return {
+                    activeFileTab: null
+                };
+            });
+        },
+
+        closeTab: (path) => {
+            set((state) => {
+                const updatedTabs = state.tabs.filter((tab) => tab.path !== path);
+                return {
+                    tabs: updatedTabs,
+                    activeFileTab: updatedTabs.length > 0
+                        ? updatedTabs[updatedTabs.length - 1]
+                        : null
+                };
+            });
+        },
+
+        clearTabs: () => {
+            set({
+                tabs: [],
+                activeFileTab: null
+            });
         }
-    }
+    };
 });

--- a/frontend/src/store/edtorValueStore.js
+++ b/frontend/src/store/edtorValueStore.js
@@ -1,0 +1,10 @@
+import { create } from "zustand";
+
+export const useEditorValueStore = create((set) => {
+  return {
+    value : null,
+    setValue : (value) => {
+      set({value})
+    }
+  }
+})


### PR DESCRIPTION
## PR Description
fix: #10
Create tabs on top of editor like in vs code.

## Feature 

- When user select file the tab on top of editor.
- Show current tab different from another tab
- Give a ❌ button so user can remove tab from tab-container.
- When no file is select the show `Select File` text.


https://github.com/user-attachments/assets/7d96256a-c42b-4fa0-bb38-9680c2494192


# Watch the video 

## Where I test
OS : Windows
Browser : Arc

`Note `: I don't run the commond on terminal so browser not shown. But it works.